### PR TITLE
fix: removed duplicate env variable KMS_KEY_ID

### DIFF
--- a/deploy/aws/cloudformation/pipebird_existing_cloud_deploy.json
+++ b/deploy/aws/cloudformation/pipebird_existing_cloud_deploy.json
@@ -551,7 +551,7 @@
     "PipeBirdS3KeyAlias": {
       "Type": "AWS::KMS::Alias",
       "Properties": {
-        "AliasName": "alias/s3",
+        "AliasName": { "Fn::Sub": "alias/${AWS::StackName}-s3" },
         "TargetKeyId": {
           "Ref": "PipeBirdS3Key"
         }

--- a/deploy/aws/cloudformation/simple_deploy.json
+++ b/deploy/aws/cloudformation/simple_deploy.json
@@ -512,7 +512,7 @@
     "PipeBirdS3KeyAlias": {
       "Type": "AWS::KMS::Alias",
       "Properties": {
-        "AliasName": "alias/s3",
+        "AliasName": { "Fn::Sub": "alias/${AWS::StackName}-s3" },
         "TargetKeyId": {
           "Ref": "PipeBirdS3Key"
         }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -19,7 +19,6 @@ const envSchema = z.object({
   S3_USER_ACCESS_ID: z.string(),
   S3_USER_SECRET_KEY: z.string(),
   PROVISIONED_BUCKET_NAME: z.string(),
-  KMS_KEY_ID: z.string(),
   AWS_REGION: z.string(),
   ENCRYPTION_KEY: z.string().min(128),
   KMS_KEY_ID: z.string().min(1),


### PR DESCRIPTION
## What is the problem?

.env had a duplicate KMS_KEY_ID field which breaks linter.

## Changes being made

Removing the duplicate field.

## How did you test this code?

Ran locally.
