### PR TITLE
New boiler plates

### DIFF
--- a/deploy/aws/cloudformation/boilerplate_bastion.json
+++ b/deploy/aws/cloudformation/boilerplate_bastion.json
@@ -376,7 +376,7 @@
           "Fn::Select": [
             0,
             {
-              "Fn::GetAZs": "us-east-1"
+              "Fn::GetAZs": { "Ref": "AWS::Region" }
             }
           ]
         },
@@ -406,7 +406,7 @@
           "Fn::Select": [
             0,
             {
-              "Fn::GetAZs": "us-east-1"
+              "Fn::GetAZs": { "Ref": "AWS::Region" }
             }
           ]
         },
@@ -436,7 +436,7 @@
           "Fn::Select": [
             1,
             {
-              "Fn::GetAZs": "us-east-1"
+              "Fn::GetAZs": { "Ref": "AWS::Region" }
             }
           ]
         },
@@ -478,7 +478,7 @@
           "Fn::Select": [
             "0",
             {
-              "Fn::GetAZs": ""
+              "Fn::GetAZs": { "Ref": "AWS::Region" }
             }
           ]
         },
@@ -680,7 +680,7 @@
           "Fn::Select": [
             0,
             {
-              "Fn::GetAZs": "us-east-1"
+              "Fn::GetAZs": { "Ref": "AWS::Region" }
             }
           ]
         },

--- a/deploy/aws/cloudformation/boilerplate_bastion.json
+++ b/deploy/aws/cloudformation/boilerplate_bastion.json
@@ -28,13 +28,25 @@
       "MaxLength": 41,
       "AllowedPattern": "[a-zA-Z0-9]+",
       "ConstraintDescription": "must contain only alphanumeric characters."
+    },
+    "DBEngine": {
+      "Description": "mysql or postgres",
+      "Type": "String",
+      "AllowedPattern": "^((mysql)|(postgres))$",
+      "ConstraintDescription": "must be either mysql or postgres"
     }
   },
   "Metadata": {
     "AWS::CloudFormation::Designer": {
       "da75044c-f493-4add-9a3f-78bae49f007f": {
-        "size": { "width": 890, "height": 220 },
-        "position": { "x": 80, "y": -90 },
+        "size": {
+          "width": 890,
+          "height": 220
+        },
+        "position": {
+          "x": 80,
+          "y": -90
+        },
         "z": 0,
         "embeds": [
           "0cdb57ad-dafc-47e4-983e-f9cd9f902a52",
@@ -46,14 +58,26 @@
         ]
       },
       "3fda5270-65e0-4442-bf48-10f2290cfe96": {
-        "size": { "width": 60, "height": 60 },
-        "position": { "x": 410, "y": -120 },
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 410,
+          "y": -120
+        },
         "z": 0,
         "embeds": []
       },
       "1ae13598-f5ce-406e-818f-8fd4eb7b6d37": {
-        "size": { "width": 120, "height": 180 },
-        "position": { "x": 478, "y": -60 },
+        "size": {
+          "width": 120,
+          "height": 180
+        },
+        "position": {
+          "x": 478,
+          "y": -60
+        },
         "z": 1,
         "parent": "da75044c-f493-4add-9a3f-78bae49f007f",
         "embeds": [
@@ -62,22 +86,40 @@
         ]
       },
       "1f526bfd-5ac4-45c1-9007-fdc168f11d93": {
-        "size": { "width": 110, "height": 160 },
-        "position": { "x": 650, "y": -45 },
+        "size": {
+          "width": 110,
+          "height": 160
+        },
+        "position": {
+          "x": 650,
+          "y": -45
+        },
         "z": 1,
         "parent": "da75044c-f493-4add-9a3f-78bae49f007f",
         "embeds": []
       },
       "58ba6df0-d3f7-4f9b-90fb-36b86a2cb246": {
-        "size": { "width": 103, "height": 140 },
-        "position": { "x": 780, "y": -30 },
+        "size": {
+          "width": 103,
+          "height": 140
+        },
+        "position": {
+          "x": 780,
+          "y": -30
+        },
         "z": 1,
         "parent": "da75044c-f493-4add-9a3f-78bae49f007f",
         "embeds": []
       },
       "7335a722-cf2a-42f2-828e-35c7956d8224": {
-        "size": { "width": 60, "height": 60 },
-        "position": { "x": 500, "y": -20 },
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 500,
+          "y": -20
+        },
         "z": 2,
         "parent": "1ae13598-f5ce-406e-818f-8fd4eb7b6d37",
         "embeds": [],
@@ -102,15 +144,27 @@
         ]
       },
       "faa25c45-3bd9-41b3-88e0-c5f04167443c": {
-        "size": { "width": 120, "height": 170 },
-        "position": { "x": 180, "y": -50 },
+        "size": {
+          "width": 120,
+          "height": 170
+        },
+        "position": {
+          "x": 180,
+          "y": -50
+        },
         "z": 1,
         "parent": "da75044c-f493-4add-9a3f-78bae49f007f",
         "embeds": ["beefb454-e51a-4f7d-99bd-f037e7491388"]
       },
       "beefb454-e51a-4f7d-99bd-f037e7491388": {
-        "size": { "width": 60, "height": 60 },
-        "position": { "x": 193, "y": -40 },
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 193,
+          "y": -40
+        },
         "z": 2,
         "parent": "faa25c45-3bd9-41b3-88e0-c5f04167443c",
         "embeds": [],
@@ -133,15 +187,27 @@
         ]
       },
       "374d3c17-4abd-46d7-8836-89ac21a7d9f4": {
-        "size": { "width": 120, "height": 170 },
-        "position": { "x": 320, "y": -50 },
+        "size": {
+          "width": 120,
+          "height": 170
+        },
+        "position": {
+          "x": 320,
+          "y": -50
+        },
         "z": 1,
         "parent": "da75044c-f493-4add-9a3f-78bae49f007f",
         "embeds": ["209849ca-f70f-4785-9539-eeac84654a5e"]
       },
       "209849ca-f70f-4785-9539-eeac84654a5e": {
-        "size": { "width": 60, "height": 60 },
-        "position": { "x": 334, "y": 50 },
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 334,
+          "y": 50
+        },
         "z": 2,
         "parent": "374d3c17-4abd-46d7-8836-89ac21a7d9f4",
         "embeds": [],
@@ -159,8 +225,14 @@
         ]
       },
       "0cdb57ad-dafc-47e4-983e-f9cd9f902a52": {
-        "size": { "width": 60, "height": 60 },
-        "position": { "x": 900, "y": -80 },
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 900,
+          "y": -80
+        },
         "z": 1,
         "parent": "da75044c-f493-4add-9a3f-78bae49f007f",
         "embeds": [],
@@ -171,38 +243,72 @@
         ]
       },
       "267b140f-f4bb-4008-9c3c-1a1ba1b2d90a": {
-        "source": { "id": "da75044c-f493-4add-9a3f-78bae49f007f" },
-        "target": { "id": "3fda5270-65e0-4442-bf48-10f2290cfe96" },
+        "source": {
+          "id": "da75044c-f493-4add-9a3f-78bae49f007f"
+        },
+        "target": {
+          "id": "3fda5270-65e0-4442-bf48-10f2290cfe96"
+        },
         "z": 0
       },
       "0cfd4876-7d3d-40dc-b585-bd10eb7908fb": {
-        "size": { "width": 180, "height": 80 },
-        "position": { "x": 1000, "y": 80 },
+        "size": {
+          "width": 180,
+          "height": 80
+        },
+        "position": {
+          "x": 1000,
+          "y": 80
+        },
         "z": 0,
         "embeds": []
       },
       "9e3554e0-9b42-43b8-bc50-5c848a885918": {
-        "size": { "width": 60, "height": 60 },
-        "position": { "x": 1080, "y": 210 },
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 1080,
+          "y": 210
+        },
         "z": 0,
         "embeds": []
       },
       "41c4240e-b736-45bd-9962-8c7157c467e2": {
-        "size": { "width": 60, "height": 60 },
-        "position": { "x": 500, "y": 57 },
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 500,
+          "y": 57
+        },
         "z": 2,
         "parent": "1ae13598-f5ce-406e-818f-8fd4eb7b6d37",
         "embeds": []
       },
       "a3bf7ed0-75d7-4ed2-a0a0-2b11abcf78bb": {
-        "size": { "width": 60, "height": 60 },
-        "position": { "x": 570, "y": 190 },
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 570,
+          "y": 190
+        },
         "z": 0,
         "embeds": []
       },
       "3458fd90-5c07-45cc-90d3-a3065117bdbe": {
-        "size": { "width": 60, "height": 60 },
-        "position": { "x": 728.3387435264402, "y": -90.41624726370384 },
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 728.3387435264402,
+          "y": -90.41624726370384
+        },
         "z": 0,
         "embeds": [],
         "iscontainedinside": ["da75044c-f493-4add-9a3f-78bae49f007f"]
@@ -217,7 +323,9 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-vpc-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-vpc-1"
+            }
           }
         ]
       },
@@ -233,7 +341,9 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-iag-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-iag-1"
+            }
           }
         ]
       },
@@ -246,8 +356,12 @@
     "TestVPCGatewayAttachment": {
       "Type": "AWS::EC2::VPCGatewayAttachment",
       "Properties": {
-        "InternetGatewayId": { "Ref": "TestInternetGateway" },
-        "VpcId": { "Ref": "TestVPC" }
+        "InternetGatewayId": {
+          "Ref": "TestInternetGateway"
+        },
+        "VpcId": {
+          "Ref": "TestVPC"
+        }
       },
       "Metadata": {
         "AWS::CloudFormation::Designer": {
@@ -259,14 +373,23 @@
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "AvailabilityZone": {
-          "Fn::Select": [0, { "Fn::GetAZs": "us-east-1" }]
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": "us-east-1"
+            }
+          ]
         },
-        "VpcId": { "Ref": "TestVPC" },
+        "VpcId": {
+          "Ref": "TestVPC"
+        },
         "CidrBlock": "112.0.1.0/24",
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-private-subnet-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-private-subnet-1"
+            }
           }
         ]
       },
@@ -280,14 +403,23 @@
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "AvailabilityZone": {
-          "Fn::Select": [0, { "Fn::GetAZs": "us-east-1" }]
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": "us-east-1"
+            }
+          ]
         },
-        "VpcId": { "Ref": "TestVPC" },
+        "VpcId": {
+          "Ref": "TestVPC"
+        },
         "CidrBlock": "112.0.0.0/24",
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-public-subnet-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-public-subnet-1"
+            }
           }
         ]
       },
@@ -301,14 +433,23 @@
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "AvailabilityZone": {
-          "Fn::Select": [1, { "Fn::GetAZs": "us-east-1" }]
+          "Fn::Select": [
+            1,
+            {
+              "Fn::GetAZs": "us-east-1"
+            }
+          ]
         },
-        "VpcId": { "Ref": "TestVPC" },
+        "VpcId": {
+          "Ref": "TestVPC"
+        },
         "CidrBlock": "112.0.2.0/24",
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-private-subnet-2" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-private-subnet-2"
+            }
           }
         ]
       },
@@ -321,23 +462,40 @@
     "TestEc2": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
-        "KeyName": { "Ref": "ec2KeyPair" },
+        "KeyName": {
+          "Ref": "ec2KeyPair"
+        },
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-ec2-bastion-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-ec2-bastion-1"
+            }
           }
         ],
         "ImageId": "ami-052efd3df9dad4825",
-        "AvailabilityZone": { "Fn::Select": ["0", { "Fn::GetAZs": "" }] },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "0",
+            {
+              "Fn::GetAZs": ""
+            }
+          ]
+        },
         "InstanceType": "t2.micro",
         "NetworkInterfaces": [
           {
             "AssociatePublicIpAddress": true,
             "DeleteOnTermination": true,
             "DeviceIndex": "0",
-            "GroupSet": [{ "Ref": "TestEC2SecurityGroup" }],
-            "SubnetId": { "Ref": "TestPublicSubnet" }
+            "GroupSet": [
+              {
+                "Ref": "TestEC2SecurityGroup"
+              }
+            ],
+            "SubnetId": {
+              "Ref": "TestPublicSubnet"
+            }
           }
         ]
       },
@@ -350,32 +508,48 @@
     "TestRouteTableSubnetAssociation": {
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {
-        "SubnetId": { "Ref": "TestPublicSubnet" },
-        "RouteTableId": { "Ref": "TestRouteTable" }
+        "SubnetId": {
+          "Ref": "TestPublicSubnet"
+        },
+        "RouteTableId": {
+          "Ref": "TestRouteTable"
+        }
       }
     },
     "TestPrivateRouteTableSubnetAssociation1": {
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {
-        "SubnetId": { "Ref": "TestPrivateSubnet1" },
-        "RouteTableId": { "Ref": "TestPrivateRouteTable" }
+        "SubnetId": {
+          "Ref": "TestPrivateSubnet1"
+        },
+        "RouteTableId": {
+          "Ref": "TestPrivateRouteTable"
+        }
       }
     },
     "TestPrivateRouteTableSubnetAssociation2": {
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {
-        "SubnetId": { "Ref": "TestPrivateSubnet2" },
-        "RouteTableId": { "Ref": "TestPrivateRouteTable" }
+        "SubnetId": {
+          "Ref": "TestPrivateSubnet2"
+        },
+        "RouteTableId": {
+          "Ref": "TestPrivateRouteTable"
+        }
       }
     },
     "TestRouteTable": {
       "Type": "AWS::EC2::RouteTable",
       "Properties": {
-        "VpcId": { "Ref": "TestVPC" },
+        "VpcId": {
+          "Ref": "TestVPC"
+        },
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-public-route-table-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-public-route-table-1"
+            }
           }
         ]
       },
@@ -388,8 +562,12 @@
     "TestPublicRouteIAG": {
       "Type": "AWS::EC2::Route",
       "Properties": {
-        "RouteTableId": { "Ref": "TestRouteTable" },
-        "GatewayId": { "Ref": "TestInternetGateway" },
+        "RouteTableId": {
+          "Ref": "TestRouteTable"
+        },
+        "GatewayId": {
+          "Ref": "TestInternetGateway"
+        },
         "DestinationCidrBlock": "0.0.0.0/0"
       },
       "Metadata": {
@@ -401,11 +579,15 @@
     "TestPrivateRouteTable": {
       "Type": "AWS::EC2::RouteTable",
       "Properties": {
-        "VpcId": { "Ref": "TestVPC" },
+        "VpcId": {
+          "Ref": "TestVPC"
+        },
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-private-route-table-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-private-route-table-1"
+            }
           }
         ]
       },
@@ -418,9 +600,13 @@
     "TestPrivateRoute": {
       "Type": "AWS::EC2::Route",
       "Properties": {
-        "RouteTableId": { "Ref": "TestPrivateRouteTable" },
+        "RouteTableId": {
+          "Ref": "TestPrivateRouteTable"
+        },
         "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId": { "Ref": "TestNATGateway" }
+        "NatGatewayId": {
+          "Ref": "TestNATGateway"
+        }
       },
       "Metadata": {
         "AWS::CloudFormation::Designer": {
@@ -434,11 +620,15 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-db-security-group-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-db-security-group-1"
+            }
           }
         ],
         "GroupDescription": "Private subnets for this test db instance.",
-        "EC2VpcId": { "Ref": "TestVPC" },
+        "EC2VpcId": {
+          "Ref": "TestVPC"
+        },
         "DBSecurityGroupIngress": [
           {
             "EC2SecurityGroupId": {
@@ -459,13 +649,19 @@
         "DBSubnetGroupDescription": "Private subnets for this db group.",
         "DBSubnetGroupName": "TestDBSubnetGroup",
         "SubnetIds": [
-          { "Ref": "TestPrivateSubnet1" },
-          { "Ref": "TestPrivateSubnet2" }
+          {
+            "Ref": "TestPrivateSubnet1"
+          },
+          {
+            "Ref": "TestPrivateSubnet2"
+          }
         ],
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-db-subnet-group-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-db-subnet-group-1"
+            }
           }
         ]
       },
@@ -481,23 +677,42 @@
       "UpdateReplacePolicy": "Delete",
       "Properties": {
         "AvailabilityZone": {
-          "Fn::Select": [0, { "Fn::GetAZs": "us-east-1" }]
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": "us-east-1"
+            }
+          ]
         },
         "AllocatedStorage": 5,
         "BackupRetentionPeriod": 0,
         "DBInstanceClass": "db.t3.micro",
         "DBInstanceIdentifier": "testdb",
-        "Engine": "MySQL",
+        "Engine": {
+          "Ref": "DBEngine"
+        },
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-db-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-db-1"
+            }
           }
         ],
-        "MasterUsername": { "Ref": "DBUser" },
-        "MasterUserPassword": { "Ref": "DBPassword" },
-        "DBSecurityGroups": [{ "Ref": "TestDBSecurityGroup" }],
-        "DBSubnetGroupName": { "Ref": "TestDBSubnetGroup" }
+        "MasterUsername": {
+          "Ref": "DBUser"
+        },
+        "MasterUserPassword": {
+          "Ref": "DBPassword"
+        },
+        "DBSecurityGroups": [
+          {
+            "Ref": "TestDBSecurityGroup"
+          }
+        ],
+        "DBSubnetGroupName": {
+          "Ref": "TestDBSubnetGroup"
+        }
       },
       "Metadata": {
         "AWS::CloudFormation::Designer": {
@@ -513,11 +728,15 @@
         "AllocationId": {
           "Fn::GetAtt": ["TestElasticIPAddress", "AllocationId"]
         },
-        "SubnetId": { "Ref": "TestPublicSubnet" },
+        "SubnetId": {
+          "Ref": "TestPublicSubnet"
+        },
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-nat-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-nat-1"
+            }
           }
         ]
       },
@@ -534,7 +753,9 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-eip-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-eip-1"
+            }
           }
         ]
       },
@@ -550,11 +771,15 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": { "Fn::Sub": "${AWS::StackName}-security-group-1" }
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}-security-group-1"
+            }
           }
         ],
         "GroupDescription": "Security group for enabling database access",
-        "VpcId": { "Ref": "TestVPC" },
+        "VpcId": {
+          "Ref": "TestVPC"
+        },
         "SecurityGroupIngress": [
           {
             "IpProtocol": "tcp",
@@ -567,7 +792,14 @@
             "FromPort": 22,
             "ToPort": 22,
             "CidrIp": {
-              "Fn::Sub": ["${ip}/32", { "ip": { "Ref": "PrimaryIPAddress" } }]
+              "Fn::Sub": [
+                "${ip}/32",
+                {
+                  "ip": {
+                    "Ref": "PrimaryIPAddress"
+                  }
+                }
+              ]
             }
           }
         ]

--- a/deploy/aws/cloudformation/boilerplate_bastion.json
+++ b/deploy/aws/cloudformation/boilerplate_bastion.json
@@ -372,14 +372,7 @@
     "TestPrivateSubnet1": {
       "Type": "AWS::EC2::Subnet",
       "Properties": {
-        "AvailabilityZone": {
-          "Fn::Select": [
-            0,
-            {
-              "Fn::GetAZs": { "Ref": "AWS::Region" }
-            }
-          ]
-        },
+        "AvailabilityZone": "us-east-1a",
         "VpcId": {
           "Ref": "TestVPC"
         },
@@ -402,14 +395,7 @@
     "TestPublicSubnet": {
       "Type": "AWS::EC2::Subnet",
       "Properties": {
-        "AvailabilityZone": {
-          "Fn::Select": [
-            0,
-            {
-              "Fn::GetAZs": { "Ref": "AWS::Region" }
-            }
-          ]
-        },
+        "AvailabilityZone": "us-east-1a",
         "VpcId": {
           "Ref": "TestVPC"
         },
@@ -432,14 +418,7 @@
     "TestPrivateSubnet2": {
       "Type": "AWS::EC2::Subnet",
       "Properties": {
-        "AvailabilityZone": {
-          "Fn::Select": [
-            1,
-            {
-              "Fn::GetAZs": { "Ref": "AWS::Region" }
-            }
-          ]
-        },
+        "AvailabilityZone": "us-east-1b",
         "VpcId": {
           "Ref": "TestVPC"
         },
@@ -474,14 +453,7 @@
           }
         ],
         "ImageId": "ami-052efd3df9dad4825",
-        "AvailabilityZone": {
-          "Fn::Select": [
-            "0",
-            {
-              "Fn::GetAZs": { "Ref": "AWS::Region" }
-            }
-          ]
-        },
+        "AvailabilityZone": "us-east-1a",
         "InstanceType": "t2.micro",
         "NetworkInterfaces": [
           {
@@ -676,14 +648,7 @@
       "DeletionPolicy": "Delete",
       "UpdateReplacePolicy": "Delete",
       "Properties": {
-        "AvailabilityZone": {
-          "Fn::Select": [
-            0,
-            {
-              "Fn::GetAZs": { "Ref": "AWS::Region" }
-            }
-          ]
-        },
+        "AvailabilityZone": "us-east-1a",
         "AllocatedStorage": 5,
         "BackupRetentionPeriod": 0,
         "DBInstanceClass": "db.t3.micro",


### PR DESCRIPTION
Added DBEngine parameter such that users can specify which database instance they want to deploy with.

Also removed 

```json
{"Fn::GetAZs": "us-east-1"}
```

Because it was only returning the array ["us-east-1a"] and missing us-east-1b, and other availability zones for whatever reason.