### PR TITLE
refactor: added base_url to admin-ui env

### DIFF
--- a/deploy/aws/cloudformation/pipebird_existing_cloud_deploy.json
+++ b/deploy/aws/cloudformation/pipebird_existing_cloud_deploy.json
@@ -170,6 +170,12 @@
             "FromPort": 3000,
             "ToPort": 3000,
             "CidrIp": "0.0.0.0/0"
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": 375,
+            "ToPort": 375,
+            "CidrIp": "0.0.0.0/0"
           }
         ],
         "SecurityGroupEgress": [
@@ -669,7 +675,7 @@
   "Mappings": {
     "DeploymentMapping": {
       "Details": {
-        "version": "0.3.1",
+        "version": "0.3.2",
         "type": "AWS_EXISTING_VPC"
       }
     }

--- a/deploy/aws/cloudformation/pipebird_simple_deploy.json
+++ b/deploy/aws/cloudformation/pipebird_simple_deploy.json
@@ -170,6 +170,12 @@
             "FromPort": 3000,
             "ToPort": 3000,
             "CidrIp": "0.0.0.0/0"
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": 375,
+            "ToPort": 375,
+            "CidrIp": "0.0.0.0/0"
           }
         ],
         "SecurityGroupEgress": [
@@ -630,7 +636,7 @@
   "Mappings": {
     "DeploymentMapping": {
       "Details": {
-        "version": "0.3.1",
+        "version": "0.3.2",
         "type": "AWS_DEFAULT_VPC"
       }
     }

--- a/deploy/configs/versions.json
+++ b/deploy/configs/versions.json
@@ -1,4 +1,5 @@
 [
+  { "version": "0.3.2", "release_date": "2022-09-12" },
   { "version": "0.3.1", "release_date": "2022-09-12" },
   { "version": "0.3.0", "release_date": "2022-09-11" },
   { "version": "0.2.2", "release_date": "2022-09-07" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,11 +73,13 @@ services:
       - pipebird-network
   pipebird-admin-ui:
     container_name: pipebird-admin-ui
-    image: pipebird/admin-ui:latest
     networks:
       - pipebird-network
     ports:
       - 375:375
+    image: pipebird/admin-ui:latest
+    environment:
+      NEXT_PUBLIC_PIPEBIRD_BASE_URL: http://api:${PORT}
 
 networks:
   pipebird-network:


### PR DESCRIPTION
## What is the problem?

admin-ui is missing NEXT_PUBLIC_PIPEBIRD_BASE_URL
Furthermore, deployed instance don't allow inbound connections to 375 (admin-ui service)

## Changes being made

Added NEXT_PUBLIC_PIPEBIRD_BASE_URL to docker-compose env
Also allowed inbound connections to port 375

## How did you test this code?

ran locally
